### PR TITLE
fix bad path in `build.nu`

### DIFF
--- a/build.nu
+++ b/build.nu
@@ -26,6 +26,6 @@ def main [package_file: path] {
     log info $"building plugin using: (ansi blue)($cmd)(ansi reset)"
     nu -c $cmd
     let ext: string = if ($nu.os-info.name == 'windows') { '.exe' } else { '' }
-    plugin add $"($install_root | path join "bin" $name)($ext)"ex
+    plugin add $"($install_root | path join "bin" $name)($ext)"
     log info "do not forget to restart Nushell for the plugin to be fully available!"
 }


### PR DESCRIPTION
related to
- c1c4940

```nushell
nupm install
```
gives me the following error :wink:
```
Error: nu::shell::io_error

  × I/O error
    ╭─[/home/amtoine/documents/repos/github.com/FMotalleb/nu_plugin_clipboard/build.nu:29:16]
 28 │     let ext: string = if ($nu.os-info.name == 'windows') { '.exe' } else { '' }
 29 │     plugin add $"($install_root | path join "bin" $name)($ext)"ex
    ·                ─────────────────────────┬────────────────────────
    ·                                         ╰── No such file or directory (os error 2)
 30 │     log info "do not forget to restart Nushell for the plugin to be fully available!"
    ╰────
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a syntax error in the build script to ensure proper addition of a plugin path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->