### PR TITLE
bump to 0.96.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,15 +6,15 @@ keywords = ["nushell", "clipboard", "plugin"]
 homepage = "https://github.com/FMotalleb/nu_plugin_clipboard"
 repository = "https://github.com/FMotalleb/nu_plugin_clipboard"
 description = "A nushell plugin to copy text into clipboard or get text from it."
-version = "0.95.0"
+version = "0.96.0"
 edition = "2021"
 readme = "README.md"
 
 [dependencies]
-nu-plugin = "0.95.0"
-nu-protocol = { version = "0.95.0", features = ["plugin"] }
+nu-plugin = "0.96.0"
+nu-protocol = { version = "0.96.0", features = ["plugin"] }
 arboard = { version = "3.3.2", default_features = false }
-nu-json = "0.95.0"
+nu-json = "0.96.0"
 
 [features]
 default = []


### PR DESCRIPTION
Nushell 0.96.0 just came out, so it's time for a version bump :wink:

i've run the following command to bump the versions
```shell
sd '0.95.0' '0.96.0' Cargo.toml
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the plugin version to 0.96.0, potentially enhancing functionality.
	- Upgraded dependencies to their latest versions, improving overall performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->