### PR TITLE
fix the Rust toolchain

### DIFF
--- a/build.nu
+++ b/build.nu
@@ -22,7 +22,14 @@ def main [package_file: path = nupm.nuon] {
             log info $message
         }
     }
-    let cmd = $"cargo install --path ($repo_root) --root ($install_root) --features=($features | str join ",")"
+
+    let channel = $repo_root
+        | path join rust-toolchain.toml
+        | open $in
+        | get toolchain?.channel?
+        | default stable
+
+    let cmd = $"cargo +($channel) install --path ($repo_root) --root ($install_root) --features=($features | str join ",")"
     log info $"building plugin using: (ansi blue)($cmd)(ansi reset)"
     nu -c $cmd
     let ext: string = if ($nu.os-info.name == 'windows') { '.exe' } else { '' }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+profile = "default"
+channel = "1.82"


### PR DESCRIPTION
on my system, i have the following Cargo version
```
cargo 1.77.2 (e52e36006 2024-03-26)
```
which cannot compile the code of `nu_plugin_clipboard` because of the following error
```
error[E0658]: use of unstable library feature 'lazy_cell'
 --> ~/.local/share/cargo/registry/src/index.crates.io-6f17d22bba15001f/nu-utils-0.100.0/src/quoting.rs:2:5
  |
2 | use std::sync::LazyLock;
  |     ^^^^^^^^^^^^^^^^^^^
  |
  = note: see issue #109736 <https://github.com/rust-lang/rust/issues/109736> for more information
```

a way to fix this would be to update Cargo as mentioned in https://github.com/FMotalleb/nu_plugin_clipboard/issues/15, but, in this PR, i propose to fix this issue for everyone, regardless of their system :smirk: 

## changelog
- add `rust-toolchain.toml` and fix the Cargo channel to `1.82` which appears to allow the code to build
- extract the channel in `build.nu` and use it explicitly with the `cargo +<channel>` syntax

> **Note**
> the issue is that, when you `nupm install` with a `build.nu`, Nupm will move to `/tmp/...` and thus the system's Cargo will be used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a configuration for managing the Rust toolchain version and profile settings.
	- Added support for specifying the Rust toolchain channel during package installation.

- **Bug Fixes**
	- Improved command execution logic for installing Rust packages by including the specified channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->